### PR TITLE
Use `lexeme` instead of `tokenize`

### DIFF
--- a/jooj.nix
+++ b/jooj.nix
@@ -1,4 +1,7 @@
-{ mkDerivation, base, containers, directory, hspec, megaparsec, QuickCheck, quickcheck-instances, raw-strings-qq, scientific, stdenv }:
+{ mkDerivation, base, containers, directory, hspec, megaparsec
+, QuickCheck, quickcheck-instances, raw-strings-qq, scientific
+, stdenv
+}:
 mkDerivation {
   pname = "jooj";
   version = "0.1.0.0";


### PR DESCRIPTION
Closes #16 
- New `colon` combinator
- `row` now uses applicative functors instead of monad do-notation
- `value` is now a `choice <list>` instead of chains of `<|>`